### PR TITLE
Ny routing for `api-public`

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -9,7 +9,7 @@ on:
       - 'CODEOWNERS'
     branches:
       - main
-      - permissions
+      - routes-cleanup
 
 env:
   IMAGE: ghcr.io/${{ github.repository }}:${{ github.sha }}

--- a/client/cypress/e2e/1_oppslag.cy.ts
+++ b/client/cypress/e2e/1_oppslag.cy.ts
@@ -23,7 +23,7 @@ describe('test av oppslag', () => {
     cy.window().then((window) => {
       const { worker, rest } = window.msw
       worker.use(
-        rest.post('/hjelpemidler/delbestilling/api/oppslag', (req, res, ctx) => {
+        rest.post('/hjelpemidler/delbestilling/api-public/oppslag', (req, res, ctx) => {
           return res.once(ctx.status(500))
         })
       )

--- a/client/src/mocks/handlers/api.ts
+++ b/client/src/mocks/handlers/api.ts
@@ -5,7 +5,7 @@ import delBestillingMock from '../../services/delbestilling-mock.json'
 import hjelpemiddelMockComet from '../../services/hjelpemiddel-mock-comet.json'
 import hjelpemiddelMockPanthera from '../../services/hjelpemiddel-mock-panthera.json'
 import hjelpemidlerMock from '../../services/hjelpemidler-mock.json'
-import { API_PATH } from '../../services/rest'
+import { API_PATH, API_PATH_PUBLIC } from '../../services/rest'
 import {
   AlleHjelpemidlerMedDelerResponse,
   DelbestillingFeil,
@@ -21,7 +21,7 @@ let tidligereBestillinger = delBestillingMock.slice(0, 4) as unknown as Delbesti
 let tidligereBestillingerKommune = delBestillingMock.slice(4) as unknown as DelbestillingSak[]
 
 const apiHandlers = [
-  rest.post<OppslagRequest, {}, OppslagResponse>(`${API_PATH}/oppslag`, (req, res, ctx) => {
+  rest.post<OppslagRequest, {}, OppslagResponse>(`${API_PATH_PUBLIC}/oppslag`, (req, res, ctx) => {
     // req.body er egentlig deprecated, men det er problemer med å inferre typen fra generic
     // https://github.com/mswjs/msw/discussions/1308#discussioncomment-3389160
     const { hmsnr } = req.body

--- a/client/src/mocks/handlers/api.ts
+++ b/client/src/mocks/handlers/api.ts
@@ -5,7 +5,7 @@ import delBestillingMock from '../../services/delbestilling-mock.json'
 import hjelpemiddelMockComet from '../../services/hjelpemiddel-mock-comet.json'
 import hjelpemiddelMockPanthera from '../../services/hjelpemiddel-mock-panthera.json'
 import hjelpemidlerMock from '../../services/hjelpemidler-mock.json'
-import { API_PATH, API_PATH_PUBLIC } from '../../services/rest'
+import { API_PATH, API_PUBLIC_PATH } from '../../services/rest'
 import {
   AlleHjelpemidlerMedDelerResponse,
   DelbestillingFeil,
@@ -21,7 +21,7 @@ let tidligereBestillinger = delBestillingMock.slice(0, 4) as unknown as Delbesti
 let tidligereBestillingerKommune = delBestillingMock.slice(4) as unknown as DelbestillingSak[]
 
 const apiHandlers = [
-  rest.post<OppslagRequest, {}, OppslagResponse>(`${API_PATH_PUBLIC}/oppslag`, (req, res, ctx) => {
+  rest.post<OppslagRequest, {}, OppslagResponse>(`${API_PUBLIC_PATH}/oppslag`, (req, res, ctx) => {
     // req.body er egentlig deprecated, men det er problemer med å inferre typen fra generic
     // https://github.com/mswjs/msw/discussions/1308#discussioncomment-3389160
     const { hmsnr } = req.body
@@ -124,10 +124,7 @@ const apiHandlers = [
   rest.get<{}, {}, DelbestillingSak[]>(`${API_PATH}/delbestilling/kommune`, (req, res, ctx) => {
     return res(ctx.delay(250), ctx.json(tidligereBestillingerKommune))
   }),
-  rest.get<{}, {}, AlleHjelpemidlerMedDelerResponse>(`${API_PATH}/hjelpemidler`, (req, res, ctx) => {
-    return res(ctx.delay(250), ctx.json(hjelpemidlerMock))
-  }),
-  rest.get<{}, {}, AlleHjelpemidlerMedDelerResponse>(`${API_PATH}/hjelpemidler`, (req, res, ctx) => {
+  rest.get<{}, {}, AlleHjelpemidlerMedDelerResponse>(`${API_PUBLIC_PATH}/hjelpemidler`, (req, res, ctx) => {
     return res(ctx.delay(250), ctx.json(hjelpemidlerMock))
   }),
 ]

--- a/client/src/services/rest.ts
+++ b/client/src/services/rest.ts
@@ -10,7 +10,7 @@ import { Delbestilling, DelbestillingSak, Valg } from '../types/Types'
 
 export const REST_BASE_PATH = '/hjelpemidler/delbestilling'
 export const API_PATH = REST_BASE_PATH + '/api'
-export const API_PATH_PUBLIC = REST_BASE_PATH + '/api-public'
+export const API_PUBLIC_PATH = REST_BASE_PATH + '/api-public'
 export const ROLLER_PATH = REST_BASE_PATH + '/roller'
 
 export class ApiError extends Error {
@@ -46,7 +46,7 @@ const fetchPost: (url: string, otherParams?: any, timeout?: number) => Promise<R
 }
 
 const hjelpemiddelOppslag = async (hmsnr: string, serienr: string): Promise<OppslagResponse> => {
-  const response = await fetchPost(API_PATH_PUBLIC + '/oppslag', {
+  const response = await fetchPost(API_PUBLIC_PATH + '/oppslag', {
     body: JSON.stringify({ hmsnr, serienr }),
     headers: {
       'Content-Type': 'application/json',
@@ -59,7 +59,7 @@ const hjelpemiddelOppslag = async (hmsnr: string, serienr: string): Promise<Opps
 }
 
 const hentAlleHjelpemidlerMedDeler = async (): Promise<AlleHjelpemidlerMedDelerResponse> => {
-  const response = await fetch(API_PATH_PUBLIC + '/hjelpemidler')
+  const response = await fetch(API_PUBLIC_PATH + '/hjelpemidler')
   await handleResponse(response.clone())
   return await response.json()
 }

--- a/client/src/services/rest.ts
+++ b/client/src/services/rest.ts
@@ -10,6 +10,7 @@ import { Delbestilling, DelbestillingSak, Valg } from '../types/Types'
 
 export const REST_BASE_PATH = '/hjelpemidler/delbestilling'
 export const API_PATH = REST_BASE_PATH + '/api'
+export const API_PATH_PUBLIC = REST_BASE_PATH + '/api-public'
 export const ROLLER_PATH = REST_BASE_PATH + '/roller'
 
 export class ApiError extends Error {
@@ -45,7 +46,7 @@ const fetchPost: (url: string, otherParams?: any, timeout?: number) => Promise<R
 }
 
 const hjelpemiddelOppslag = async (hmsnr: string, serienr: string): Promise<OppslagResponse> => {
-  const response = await fetchPost(API_PATH + '/oppslag', {
+  const response = await fetchPost(API_PATH_PUBLIC + '/oppslag', {
     body: JSON.stringify({ hmsnr, serienr }),
     headers: {
       'Content-Type': 'application/json',

--- a/client/src/services/rest.ts
+++ b/client/src/services/rest.ts
@@ -59,7 +59,7 @@ const hjelpemiddelOppslag = async (hmsnr: string, serienr: string): Promise<Opps
 }
 
 const hentAlleHjelpemidlerMedDeler = async (): Promise<AlleHjelpemidlerMedDelerResponse> => {
-  const response = await fetch(API_PATH + '/hjelpemidler')
+  const response = await fetch(API_PATH_PUBLIC + '/hjelpemidler')
   await handleResponse(response.clone())
   return await response.json()
 }

--- a/server/src/reverseProxy.ts
+++ b/server/src/reverseProxy.ts
@@ -32,7 +32,7 @@ const envProperties = {
 function pathRewriteBasedOnEnvironment(req: Request): string {
   return req.originalUrl
     .replace('/hjelpemidler/delbestilling/api', '/api')
-    .replace(new RegExp('hjelpemidler/delbestilling/api-public/[a-zA-Z]*'), '/api-public')
+    .replace(new RegExp('hjelpemidler/delbestilling/api-public/?(.*)'), '/api-public')
     .replace('/hjelpemidler/delbestilling/roller', '/api')
     .replace('/hjelpemidler/delbestilling/hjelpemiddeldatabasen', '/graphql')
 }

--- a/server/src/reverseProxy.ts
+++ b/server/src/reverseProxy.ts
@@ -32,7 +32,7 @@ const envProperties = {
 function pathRewriteBasedOnEnvironment(req: Request): string {
   return req.originalUrl
     .replace('/hjelpemidler/delbestilling/api', '/api')
-    .replace(new RegExp('hjelpemidler/delbestilling/api-public/?(.*)'), '/api-public')
+    .replace('/hjelpemidler/delbestilling/api-public/', '/api-public')
     .replace('/hjelpemidler/delbestilling/roller', '/api')
     .replace('/hjelpemidler/delbestilling/hjelpemiddeldatabasen', '/graphql')
 }

--- a/server/src/reverseProxy.ts
+++ b/server/src/reverseProxy.ts
@@ -32,6 +32,7 @@ const envProperties = {
 function pathRewriteBasedOnEnvironment(req: Request): string {
   return req.originalUrl
     .replace('/hjelpemidler/delbestilling/api', '/api')
+    .replace(new RegExp('hjelpemidler/delbestilling/api-public/[a-zA-Z]*'), '/api-public')
     .replace('/hjelpemidler/delbestilling/roller', '/api')
     .replace('/hjelpemidler/delbestilling/hjelpemiddeldatabasen', '/graphql')
 }

--- a/server/src/reverseProxy.ts
+++ b/server/src/reverseProxy.ts
@@ -45,6 +45,7 @@ function setup() {
 
 const handlers = {
   api: (): RequestHandler => proxy(envProperties.API_URL, options(config.app.targetAudienceAPI)),
+  apiPublic: (): RequestHandler => proxy(envProperties.API_URL, options(config.app.targetAudienceAPI)),
   roller: (): RequestHandler => proxy(envProperties.ROLLER_URL, options(config.app.targetAudienceRoller)),
 }
 

--- a/server/src/routes.ts
+++ b/server/src/routes.ts
@@ -25,6 +25,12 @@ export const routes = {
     })
     return router
   },
+  apiPublic(): Router {
+    reverseProxy.setup()
+    const router = Router()
+    router.use(reverseProxy.handlers.apiPublic())
+    return router
+  },
   api(): Router {
     reverseProxy.setup()
     const router = Router()

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -20,6 +20,7 @@ server.use(session())
 
 const router = express.Router()
 router.use('/internal/', routes.internal())
+router.use('/api-public/', routes.apiPublic())
 router.use('/api/', authMiddleware.requiresValidToken(), routes.api())
 router.use('/roller/', authMiddleware.requiresValidToken(), routes.roller())
 router.use('/', routes.auth())

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -20,7 +20,7 @@ server.use(session())
 
 const router = express.Router()
 router.use('/internal/', routes.internal())
-router.use('/api/', /*authMiddleware.requiresValidToken(),*/ routes.api())
+router.use('/api/', authMiddleware.requiresValidToken(), routes.api())
 router.use('/roller/', authMiddleware.requiresValidToken(), routes.roller())
 router.use('/', routes.auth())
 router.use('/', routes.public(server))


### PR DESCRIPTION
Vi har idag to APIer: et åpent (for `POST /oppslag` og `GET /hjelpemidler`) og et lukket (for f.eks `POST /delbestilling`). Men i backend-for-frontend serveren vår går disse via samme handler, nemlig `/api`, som ikke har noe middleware for å sjekke at bruker har riktig token. Requester som krever token vil uansett feile når de treffer `hm-delbestilling-api`, men jeg føler det er mest riktig å ha en middleware i vår egen routing som kan avskjære requestet tidligere.

Tenker derfor vi kan legge til `authMiddleware.requiresValidToken` på `/api` og lage en ny handler som heter `api-public` som da ikke har dette middlewaret. Tilsvarende routing er foreslått for [hm-delbestilling-api](https://github.com/navikt/hm-delbestilling-api/pull/16/files)