### PR TITLE
Tekstjustering: det finnes ikke en bruker vi kan referere til i denne konteksten

### DIFF
--- a/client/src/assets/locales/nb/translation.json
+++ b/client/src/assets/locales/nb/translation.json
@@ -43,7 +43,7 @@
   "error.informasjonForUtviklere": "Informasjon for utviklere",
   "error.klarteIkkeSjekkeLoginStatus": "Vi klarte ikke å sjekke loginstatus akkurat nå. Prøv igjen senere.",
   "error.ULIK_GEOGRAFISK_TILKNYTNING": "Du kan ikke bestille deler til bruker som ikke tilhører den kommunen du jobber i.",
-  "error.INGET_UTLÅN": "Det finnes ikke noe utlån for denne brukeren på dette artikkel- og serienummer. Ta kontakt med hjelpemiddelsentralen.",
+  "error.INGET_UTLÅN": "Det finnes ikke noe utlån for dette artikkel- og serienummeret. Ta kontakt med hjelpemiddelsentralen.",
   "error.KAN_IKKE_BESTILLE": "Du kan ikke bestille deler til dette hjelpemiddelet digitalt. Ta kontakt med hjelpemiddelsentralen.",
   "error.BRUKER_IKKE_FUNNET": "Vi klarte ikke å finne noen bruker knyttet til dette artikkel- og serienummer. Ta kontakt med hjelpemiddelsentralen.",
   "error.BESTILLE_TIL_SEG_SELV": "Du har ikke lov til å bestille deler til produkter du selv har utlån på.",

--- a/client/src/assets/locales/nn/translation.json
+++ b/client/src/assets/locales/nn/translation.json
@@ -43,7 +43,7 @@
   "error.informasjonForUtviklere": "Informasjon for utviklarar",
   "error.klarteIkkeSjekkeLoginStatus": "Me klarte ikkje å sjekka loginstatus akkurat no. Prøv igjen seinare.",
   "error.ULIK_GEOGRAFISK_TILKNYTNING": "Du kan ikkje bestilla delar til brukar som ikkje tilhøyrer den kommunen du jobbar i.",
-  "error.INGET_UTLÅN": "Det finst ikkje noko utlån for denne brukaren på dette artikkel- og serienummer. Ta kontakt med hjelpemiddelsentralen.",
+  "error.INGET_UTLÅN": "Det finst ikkje noko utlån for dette artikkel- og serienummeret. Ta kontakt med hjelpemiddelsentralen.",
   "error.KAN_IKKE_BESTILLE": "Du kan ikkje bestilla delar til dette hjelpemiddelet digitalt. Ta kontakt med hjelpemiddelsentralen.",
   "error.BRUKER_IKKE_FUNNET": "Me klarte ikkje å finna nokon bruker knytt til dette artikkel- og serienummer. Ta kontakt med hjelpemiddelsentralen.",
   "error.BESTILLE_TIL_SEG_SELV": "Du har ikkje lov til å bestilla delar til produkt du sjølv har utlån på.",


### PR DESCRIPTION
Dersom tekniker gjer eit oppslag, og vi ikkje finner utlånet (for artnr+serienr) i OeBS, så blir det rart å referere til "denne brukeren". Tekniker har ikkje lagt inn noko bruker, kun eit hjelpemiddel.